### PR TITLE
Remove direct call to session_write_close()

### DIFF
--- a/Task/TaskManager.php
+++ b/Task/TaskManager.php
@@ -174,7 +174,11 @@ class TaskManager
     public function execute(PostResponseEvent $event)
     {
         if ($this->isEnabled() && $this->masterRequest) {
-            session_write_close();
+            $session = $event->getRequest()->getSession();
+            if (null !== $session) {
+                // Saves the session, which calls PHP's session_write_close()
+                $session->save();
+            }
 
             // Allow any loaded plugins to fire
             foreach ($this->getPlugins() as $plugin) {


### PR DESCRIPTION
Instead, retrieve the Symfony session and save it (if present). This will properly close the session.

Resolves #1 