### PR TITLE
Create generic callable task

### DIFF
--- a/Task/CallableTask.php
+++ b/Task/CallableTask.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace As3\Bundle\PostProcessBundle\Task;
+
+/**
+ * Task for running a callable property.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class CallableTask implements TaskInterface
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @param   callable    $callable
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        $callable = $this->callable;
+        $callable();
+    }
+}


### PR DESCRIPTION
Creates a task that wraps `callable` properties (such as Closures, etc). This task can then be added to the `TaskManager` for execution.