### PR TITLE
Only run plugins when there are tasks

### DIFF
--- a/Task/TaskManager.php
+++ b/Task/TaskManager.php
@@ -209,7 +209,7 @@ class TaskManager
         }
         $this->masterRequest = true;
 
-        if ((!$this->hasTasks() && !$this->hasPlugins()) || !$this->isEnabled()) {
+        if (!$this->hasTasks() || !$this->isEnabled()) {
             // Nothing to process. Return response.
             return $response;
         }


### PR DESCRIPTION
When only a plugin was enabled (no tasks), the entire response was being modified **as if** there were tasks assigned. This was causing unintended results.

Going forward:
- Plugins should only manipulate the response when post process tasks are set.
- The response headers and content should only be modified when tasks are set -  **not** when only plugins are set.

